### PR TITLE
docs(repo): migrate documentation

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Aether
+
+First off, thank you for contributing to Aether!
+
+Aether is a highly security-sensitive project. Our primary goal is to provide a fully decentralized, metadata-free peer-to-peer communication platform over the Tor network. Because a single IP leak or cryptographic flaw can compromise the physical safety of our users, we adhere to strict "Security by Design" principles.
+
+This document outlines our development methodology, coding conventions, and contribution workflows to ensure we maintain the highest standards of code quality and security.
+
+---
+
+## 1. Branching Strategy & Workflow
+
+We follow a **Feature Branch Workflow** based on Trunk-Based Development. The `main` branch is protected and must always be in a deployable, stable state.
+
+### 1.1 Branch Naming Conventions
+
+Always branch off from `main`. Use the following naming convention for your branches:
+
+* `feature/<issue-number>-<short-description>` (e.g., `feature/12-implement-tor-bootstrap`)
+* `bugfix/<issue-number>-<short-description>` (e.g., `bugfix/34-fix-sqlite-lock`)
+* `docs/<short-description>` (e.g., `docs/update-architecture-diagram`)
+* `refactor/<short-description>` (e.g., `refactor/api-response-models`)
+
+### 1.2 Pull Request (PR) Process
+
+Direct pushes to `main` are strictly forbidden. All changes must be merged via Pull Requests.
+
+1. **Four-Eyes Principle:** Every PR requires at least one approving review from another team member before it can be merged. This is critical for catching potential security flaws.
+2. **CI/CD Checks:** The GitHub Actions pipeline must pass completely (linters, unit tests, and security scans) before merging.
+3. **PR Description:** Clearly describe *what* was changed, *why* it was changed, and mention any related Issue numbers (e.g., "Resolves #12").
+
+---
+
+## 2. Commit Message Conventions
+
+We strictly follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. This ensures a readable project history and enables automated changelog generation.
+
+**Format:**
+`<type>(<scope>): <subject>`
+
+**Allowed Types:**
+
+* `feat`: A new feature
+* `fix`: A bug fix
+* `docs`: Documentation only changes
+* `style`: Changes that do not affect the meaning of the code (white-space, formatting, etc.)
+* `refactor`: A code change that neither fixes a bug nor adds a feature
+* `test`: Adding missing tests or correcting existing tests
+* `chore`: Changes to the build process or auxiliary tools
+
+**Examples:**
+
+* `feat(tor): integrate stem library for hidden service bootstrapping`
+* `fix(api): sanitize user input in contact creation endpoint`
+* `docs(readme): add local setup instructions for python virtual environment`
+
+---
+
+## 3. Coding Conventions & Clean Code
+
+To satisfy our high code quality requirements, all code must be written in **English** (variables, methods, comments) and adhere to the following standards.
+
+### 3.1 Python (Backend, Controller, REST API)
+
+* **Standard:** Adhere to [PEP 8](https://peps.python.org/pep-0008/).
+* **Formatter:** Use `Black` (line length: 88 characters).
+* **Linter:** Use `Flake8` or `Pylint` to catch logical errors and enforce style.
+* **Typing:** Use Python Type Hinting (e.g., `def get_contact(onion_address: str) -> dict:`) extensively to make the code self-documenting and prevent runtime type errors.
+* **API Design:** The Flask REST API must use clear, resource-oriented endpoint naming (e.g., `GET /api/v1/contacts`) and always return proper HTTP status codes.
+
+### 3.2 JavaScript / UI (Electron Frontend)
+
+* **Formatter:** Use `Prettier` for consistent code formatting.
+* **Linter:** Use `ESLint` to catch potential JavaScript pitfalls.
+* **Modularity:** Keep UI components decoupled from the IPC (Inter-Process Communication) and API calling logic.
+
+### 3.3 Documentation and Comments
+
+* **Self-Documenting Code:** Choose descriptive variable and function names (e.g., `initialize_tor_daemon()` instead of `init_td()`).
+* **Why over What:** Comments should explain *why* a specific approach was taken, especially concerning complex cryptographic implementations, Tor latency workarounds, or specific security trade-offs.
+
+---
+
+## 4. Security & Privacy Guidelines (Important)
+
+All code must be evaluated against our threat model.
+
+1. **Zero IP Leaks:** The Electron frontend and Python backend **must never** make direct external HTTP requests to the public internet. All external communication must be routed exclusively through the local Tor SOCKS5 proxy.
+2. **Data Minimization & Logging:** Never log sensitive information (e.g., private keys, raw message contents, or plaintext Onion addresses of contacts). If errors occur, log the error types without sensitive context.
+3. **Database Security (SQLite):** * Always use parameterized queries or an ORM (like SQLAlchemy) to prevent SQL injection.
+   * Ensure that the SQLite database file on the disk is symmetrically encrypted at rest (as per our requirements).
+
+---
+
+## 5. Testing Requirements
+
+Aether's reliability directly impacts user security. Therefore:
+
+* Write **Unit Tests** for all core logic (especially cryptography, Tor interaction, and database queries).
+* Write **Integration Tests** for the REST API endpoints.
+* Run all tests locally before opening a Pull Request.

--- a/doc/OPERATIONS.md
+++ b/doc/OPERATIONS.md
@@ -1,0 +1,77 @@
+# Operations & Deployment Strategy (OPERATIONS.md)
+
+## 1. Introduction & DevOps Philosophy
+
+Due to Aether's strictly decentralized Peer-to-Peer (P2P) architecture and its reliance on the Tor network for routing, the application does not require centralized backend servers, relay nodes, or external databases. Consequently, classical IT operations and server maintenance are not applicable.
+
+In the context of Aether, "Operations" encompasses the automated Quality Assurance (CI/CD pipeline), the secure compilation and distribution of the software to the end-user (Release Management), and the lifecycle management of the product (End-of-Life planning). Our operational processes are designed to uphold the project's core principle of "Security by Design".
+
+## 2. Continuous Integration (CI) & Supply Chain Security
+
+To prevent human error and ensure that every commit meets our strict security and quality standards, we utilize **GitHub Actions** as our centralized CI/CD platform.
+
+### 2.1 Quality Gates and Automated Testing
+
+Every accepted Pull Request to the `main` branch triggers a comprehensive CI pipeline. Code is only eligible for merging if it passes the following automated quality gates:
+
+* **Linting & Formatting:** Enforced via `Pylint` (Backend) and `ESLint`/`Prettier` (Frontend) to maintain clean code standards.
+* **Test Execution:** Execution of the `pytest` and `Jest` suites. The pipeline fails if the backend test coverage drops below **70%**.
+* **Static Application Security Testing (SAST):** `SonarQube` scans the codebase. The pipeline immediately halts if any critical or high-severity vulnerabilities are detected.
+
+### 2.2 Supply Chain Security
+
+Given the severe threat model of our target audience (e.g., investigative journalists), securing third-party dependencies is paramount. We employ **Dependabot** to continuously monitor all `npm` and `pip` dependencies for known vulnerabilities (CVEs). Vulnerable dependencies automatically trigger a security alert and generate a PR for dependency patching.
+
+## 3. Continuous Deployment (CD) & Release Management
+
+The build and distribution processes are entirely automated to ensure reproducible builds and eliminate manual tampering risks during the compilation phase.
+
+### 3.1 Automated Build Process
+
+Aether's primary target environments are security- and privacy-focused operating systems (e.g., Tails OS, Whonix). Therefore, official binary releases are exclusively built for **GNU/Linux**.
+
+The automated CD pipeline is triggered when a developer pushes a new version tag (e.g., `v1.0.0`) to the `main` branch:
+
+1. **Backend Bundling:** `PyInstaller` bundles the Python/Flask middleware, Tor wrappers and all dependencies into a standalone executable, freezing the Python environment.
+2. **Frontend Packaging:** `electron-builder` packages the Electron frontend and the bundled backend.
+3. **Artifact Generation:** The pipeline outputs a self-contained `.AppImage` file, ensuring out-of-the-box compatibility across major GNU/Linux distributions.
+
+### 3.2 Cryptographic Signing Strategy
+
+To protect users against supply-chain attacks (e.g., compromised GitHub servers), all releases are cryptographically signed.
+
+* **Current Automation (Beta Phase):** During the current project phase, the CI/CD pipeline automatically signs the release tags and the generated `.AppImage` binaries using a dedicated GPG key stored in GitHub Secrets.
+* **Future Transition (Production Maturity):** As the project matures and reaches a larger user base, the signing process will transition to an "offline signing" model. Automated CI/CD signing will be disabled, and core maintainers will download the reproducible builds, verify them, and sign the release archives locally to futher increase security.
+
+## 4. Delivery and Update Procedure
+
+Standard automatic background updates are considered a security risk in high-threat environments, as they can be exploited to silently push malicious payloads to targeted users.
+
+### 4.1 Update Checks via Tor
+
+Aether **does not** feature silent auto-updates. Instead, the application implements a privacy-preserving update notification system:
+
+1. Upon application startup, the software queries the GitHub Releases API for new version tags.
+2. **Crucial Security Constraint:** To strictly prevent IP leaks (NFR-01), the Electron frontend does *not* make this HTTP request directly. The request is routed through the local Flask backend, which tunnels the API call exclusively through the local Tor SOCKS5 proxy.
+3. If a new version is found, a non-intrusive banner appears in the GUI informing the user. The user is instructed to download the new `.AppImage` and manually verify its GPG signature before execution.
+
+## 5. Build from Source (Developer & Tech Enthusiast Experience)
+
+For users who want to verify and compile the software themselves, we provide full access to the source code alongside a streamlined setup process.
+
+To prevent cumbersome manual setups of virtual environments and node modules, we provide a cross-platform **Makefile**. Users can simply clone the repository and execute:
+
+* `make install`: Automatically sets up the Python `venv`, installs `pip` requirements, and runs `npm install`.
+* `make run`: Boots the local Tor mock, starts the Flask backend, and launches the Electron GUI in development mode.
+
+Additionally, for those who want to prefer a fully manual installation, we provide step-by-step instructions in our README.
+
+## 6. End-of-Life (EOL) & Sunset Strategy
+
+A decentralized application poses a unique challenge: there are no central servers to shut down. Even if active development ceases, users could theoretically continue using Aether indefinitely. However, unpatched cryptographic libraries or outdated Tor daemons eventually become critical security vulnerabilities.
+
+To responsibly manage the project's End-of-Life, the following Sunset Strategy is defined:
+
+1. **Repository Archiving:** The GitHub repository will be set to "Read-Only / Archived", and the `README.md` will be updated with a prominent "ABANDONED / EOL" security warning.
+2. **Final Sunset Release:** A final update will be published. This version will hardcode a permanent, un-dismissible warning banner in the Graphical User Interface: *"Software EOL: This software no longer receives security updates. Continued use poses a severe security risk."*
+3. **Data Offboarding:** The final release notes and documentation will guide users to utilize the **Export Encrypted Backup (UC-10)** feature. This allows users to securely extract their cryptographic identity and contact lists before permanently deleting the Aether client from their machines.

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,0 +1,100 @@
+# Quality Assurance & Testing Strategy (TESTING.md)
+
+## 1. Introduction and Objectives
+
+This document outlines the quality assurance and testing strategy for the **Aether** project. As Aether is a highly sensitive communication platform whose primary goal is the strict avoidance of metadata and IP leaks, our quality assurance efforts are heavily focused on the principle of **Security by Design**.
+
+## 2. Testing Strategy and Test Levels
+
+We pursue a risk-based testing approach, divided into several levels to balance between execution speed and system coverage.
+
+### 2.1 Unit Tests (Focus: High)
+
+Unit tests form the foundation of our quality assurance, testing isolated components without external dependencies.
+
+* **Backend (Python/Flask):** We use `pytest` for testing the middleware and cryptography modules. The focus is on verifying encryption and decryption routines, as well as the correct processing of SQLite database operations.
+* **Frontend (JavaScript/Electron):** We use `Jest` for testing the frontend logic and state management, independent of the user interface and inter-process communication (IPC).
+
+### 2.2 Integration Tests (Focus: Medium)
+
+Integration tests verify the interaction between individual modules.
+
+* **Backend & Database:** Verifying that the Flask REST API correctly writes data to and reads data from the SQLite database.
+* **Tor Network Mocks:** Since real Tor connections are too unstable and slow for automated CI/CD pipelines, we use **pure software mocks** within the Python code to simulate the Tor daemon. This allows us to deterministically test the application's behavior under simulated latencies and network conditions.
+
+### 2.3 System & UI Tests (Focus: Selective)
+
+* **Frontend E2E:** We rely on **manual end-to-end (E2E) testing** for the Electron app. These manual test cycles ensure that user interactions in the GUI (e.g., adding a contact, initiating a call) trigger the correct API calls to the middleware and that the overall user experience meets our quality standards.
+
+## 3. Security-Critical and Complex Test Cases
+
+To address Aether's specific architectural risks, the following mission-critical test cases have been defined and must be verified with every code change:
+
+* **Test Case 1: Zero IP Leaks (NFR-01)**
+  * *Description:* An integration test mocks the network module and blocks the SOCKS5 proxy.
+  * *Expected Behavior:* The application strictly applies the fail-closed principle. The system must actively block any outgoing request that attempts to bypass the SOCKS5 proxy. This ensures that no fallback to direct HTTP/UDP requests (clearnet) is possible, thereby protecting the user's identity.
+* **Test Case 2: Tor Latency and Queuing (FR-06 & NFR-08)**
+  * *Description:* Using software mocks, extreme network latency (> 2000ms) and a temporary connection drop to the remote peer are simulated.
+  * *Expected Behavior:* Outgoing messages are not discarded but marked as "Queued" in the local SQLite database. They are automatically resent as soon as the Tor mock signals reachability again.
+* **Test Case 3: Post-Compromise Security Handshake (FR-04)**
+  * *Description:* Simulation of a connection establishment between two peers for cryptographic key generation.
+  * *Expected Behavior:* Verification that temporary session keys are generated for each new session and are securely wiped from memory immediately after the session concludes (Perfect Forward Secrecy).
+* **Test Case 4: Data-at-Rest Encryption (NFR-04)**
+  * *Description:* The backend tests initialize a temporary SQLite database.
+  * *Expected Behavior:* The test verifies at the file-system level that the generated `.db` file cannot be read without the correct symmetric key (AES-256).
+
+## 4. CI/CD Pipeline and DevOps
+
+Our Continuous Integration pipeline is automated via **GitHub Actions** and runs on every push to a feature branch as well as on every Pull Request.
+
+### Pipeline Flow & Tools
+
+1. **Linting & Formatting:** Code inspection using `Pylint` (Python), alongside `ESLint` and `Prettier` (JS).
+2. **Security Scans (SonarQube):** All code is analyzed by SonarQube to detect static security vulnerabilities, hardcoded secrets, or code smells early in the development lifecycle.
+3. **Automated Testing:** Execution of all `pytest` and `Jest` test suites.
+
+### Quality Gates
+
+A Pull Request can only be merged into the `main` branch if the following conditions are met:
+
+* **Code Coverage:** The test coverage measured by `pytest-cov` must be at least **70%**.
+* **Security:** SonarQube reports **0 critical and 0 high vulnerabilities**.
+* **Four-Eyes Principle:** At least one other developer has reviewed and approved the code.
+
+## 5. Instructions for Local Test Execution
+
+Before code is committed, all tests must run successfully in the local development environment.
+
+**Prerequisites:** Python 3.x, Node.js, and an active Virtual Environment (`venv`).
+
+* **Run Backend Tests (Python):**
+
+  ```bash
+  # In the project root directory
+  pytest
+  ```
+
+* **Generate Backend Coverage Report:**
+
+  ```bash
+  # Checks if the 70% Quality Gate is met
+  pytest --cov=src --cov-report=term-missing
+  ```
+
+* **Run Frontend Tests (JavaScript/Electron):**
+
+  ```bash
+  # Inside the /src-frontend directory
+  npm run test
+  ```
+
+## 6. Quality Assurance and Bug Tracking
+
+Our team places great emphasis on systematic bug resolution to prevent technical debt.
+
+* **Issue Tracking:** Every identified bug must be logged as a GitHub Issue with the `bug` label.
+* **Report Structure:** A valid bug report mandatorily includes:
+  1. *Steps to reproduce*
+  2. *Expected behavior*
+  3. *Actual behavior*
+* **Regression Testing:** When a bug is fixed (using the branch prefix `bugfix/`), an accompanying unit or integration test **must** be written. This test ensures that the exact same error will be immediately caught by the CI/CD pipeline if the code is altered again in the future.


### PR DESCRIPTION
Moves documentation from temporary directory to final \doc/\ directory. Resolves #5