### PR TITLE
chore(deps): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/src-frontend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Sets up Dependabot for backend and frontend supply chain security correctly tracking their specific package managers as outlined in Operations. Resolves #9